### PR TITLE
feat: Phase 5 Dev B — mobile optimization & warehouse daily summary

### DIFF
--- a/app/(dashboard)/admin/orders/[id]/page.tsx
+++ b/app/(dashboard)/admin/orders/[id]/page.tsx
@@ -281,7 +281,9 @@ function StatusTimeline({ status }: { status: TicketStatus }) {
             <p className="text-[10px] font-bold tracking-widest uppercase text-gray-400 mb-3">
                 Order progress
             </p>
-            <div className="flex items-start">
+
+            {/* ── Horizontal layout — sm and above ── */}
+            <div className="hidden sm:flex items-start">
                 {TIMELINE_STEPS.map((step, i) => {
                     const isDone = !isTerminal && i < currentIdx;
                     const isActive = !isTerminal && i === currentIdx;
@@ -303,7 +305,6 @@ function StatusTimeline({ status }: { status: TicketStatus }) {
                                     }}
                                 />
                             )}
-
                             {/* Dot */}
                             <div
                                 className={`relative z-10 w-[22px] h-[22px] rounded-full border-2 flex items-center justify-center transition-all ${
@@ -328,10 +329,73 @@ function StatusTimeline({ status }: { status: TicketStatus }) {
                                     <div className="w-2 h-2 rounded-full bg-indigo-600" />
                                 ) : null}
                             </div>
-
                             {/* Label */}
                             <span
                                 className={`mt-1.5 text-[10px] text-center leading-tight font-medium ${
+                                    isReject
+                                        ? "text-red-500 font-semibold"
+                                        : isDone || isActive
+                                          ? "text-gray-800 font-semibold"
+                                          : "text-gray-400"
+                                }`}
+                            >
+                                {STATUS_META[step].label}
+                            </span>
+                        </div>
+                    );
+                })}
+            </div>
+
+            {/* ── Vertical layout — mobile only ── */}
+            <div className="flex flex-col sm:hidden">
+                {TIMELINE_STEPS.map((step, i) => {
+                    const isDone = !isTerminal && i < currentIdx;
+                    const isActive = !isTerminal && i === currentIdx;
+                    const isReject = isTerminal && step === "submitted";
+                    const isLast = i === TIMELINE_STEPS.length - 1;
+
+                    return (
+                        <div key={step} className="flex items-start gap-3">
+                            {/* Dot + vertical connector */}
+                            <div className="flex flex-col items-center flex-shrink-0">
+                                <div
+                                    className={`w-5 h-5 rounded-full border-2 flex items-center justify-center transition-all ${
+                                        isReject
+                                            ? "border-red-400 bg-red-400"
+                                            : isDone
+                                              ? "border-indigo-600 bg-indigo-600"
+                                              : isActive
+                                                ? "border-indigo-600 bg-white ring-4 ring-indigo-100"
+                                                : "border-gray-200 bg-white"
+                                    }`}
+                                >
+                                    {isReject ? (
+                                        <X size={9} className="text-white" />
+                                    ) : isDone ? (
+                                        <CheckCircle2
+                                            size={9}
+                                            className="text-white"
+                                            strokeWidth={2.5}
+                                        />
+                                    ) : isActive ? (
+                                        <div className="w-1.5 h-1.5 rounded-full bg-indigo-600" />
+                                    ) : null}
+                                </div>
+                                {!isLast && (
+                                    <div
+                                        className="w-px flex-shrink-0 mt-1 mb-1"
+                                        style={{
+                                            height: "20px",
+                                            background: isDone
+                                                ? "#6366f1"
+                                                : "#e5e7eb",
+                                        }}
+                                    />
+                                )}
+                            </div>
+                            {/* Label */}
+                            <span
+                                className={`text-xs leading-tight pt-0.5 font-medium ${
                                     isReject
                                         ? "text-red-500 font-semibold"
                                         : isDone || isActive
@@ -774,41 +838,44 @@ export default function TicketDetailPage() {
     return (
         <div className="min-h-screen bg-white">
             {/* ── Top bar ── */}
-            <div className="flex items-center gap-3 px-6 py-4 border-b border-gray-100">
-                <button
-                    onClick={() => router.push("/admin/orders")}
-                    className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-indigo-600 border border-gray-200 hover:border-violet-300 px-3 py-1.5 rounded-lg transition-all"
-                >
-                    <ArrowLeft size={12} /> Orders
-                </button>
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-100">
+                {/* Left: back + ID + badges */}
+                <div className="flex items-center gap-2 flex-wrap">
+                    <button
+                        onClick={() => router.push("/admin/orders")}
+                        className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-indigo-600 border border-gray-200 hover:border-violet-300 px-3 py-1.5 rounded-lg transition-all"
+                    >
+                        <ArrowLeft size={12} /> Orders
+                    </button>
 
-                {/* Ticket ID */}
-                <span
-                    style={{ fontFamily: "var(--font-mono, monospace)" }}
-                    className="text-sm font-medium text-gray-600"
-                    title={t.id}
-                >
-                    {shortId(t.id)}
-                </span>
-
-                <StatusBadge status={status} />
-
-                {/* Partial fulfillment badge */}
-                {hasPartialFulfillment && (
-                    <span className="text-[10px] font-bold bg-amber-50 text-amber-700 px-2 py-0.5 rounded-full border border-amber-200">
-                        Partial fill
+                    {/* Ticket ID */}
+                    <span
+                        style={{ fontFamily: "var(--font-mono, monospace)" }}
+                        className="text-sm font-medium text-gray-600"
+                        title={t.id}
+                    >
+                        {shortId(t.id)}
                     </span>
-                )}
 
-                {/* Auto-approved badge */}
-                {t.is_auto_approved && (
-                    <span className="text-[10px] font-bold bg-emerald-50 text-emerald-700 px-2 py-0.5 rounded-full border border-emerald-200">
-                        Auto-approved
-                    </span>
-                )}
+                    <StatusBadge status={status} />
 
-                {/* Action buttons — right side */}
-                <div className="ml-auto flex items-center gap-2">
+                    {/* Partial fulfillment badge */}
+                    {hasPartialFulfillment && (
+                        <span className="text-[10px] font-bold bg-amber-50 text-amber-700 px-2 py-0.5 rounded-full border border-amber-200">
+                            Partial fill
+                        </span>
+                    )}
+
+                    {/* Auto-approved badge */}
+                    {t.is_auto_approved && (
+                        <span className="text-[10px] font-bold bg-emerald-50 text-emerald-700 px-2 py-0.5 rounded-full border border-emerald-200">
+                            Auto-approved
+                        </span>
+                    )}
+                </div>
+
+                {/* Right: action buttons */}
+                <div className="flex items-center gap-2 sm:ml-auto flex-wrap">
                     {/* Cancel — only when submitted. Component self-hides for other statuses. */}
                     <CancelOrderDialog
                         ticketId={t.id}
@@ -872,7 +939,7 @@ export default function TicketDetailPage() {
             </div>
 
             {/* ── Body ── */}
-            <div className="px-6 py-5 grid grid-cols-[1fr_272px] gap-5 max-w-6xl">
+            <div className="px-4 sm:px-6 py-5 grid grid-cols-1 md:grid-cols-[1fr_272px] gap-5 max-w-6xl">
                 {/* ── LEFT ── */}
                 <div>
                     {/* Timeline */}

--- a/app/(dashboard)/admin/orders/new/page.tsx
+++ b/app/(dashboard)/admin/orders/new/page.tsx
@@ -21,7 +21,9 @@ import {
     Store,
     Warehouse,
     ChevronDown,
+    ChevronUp,
 } from "lucide-react";
+import { Sheet } from "react-modal-sheet";
 import { toast } from "react-hot-toast";
 
 import {
@@ -450,12 +452,13 @@ function CatalogItemRow({
                 <div className="flex items-center">
                     <button
                         onClick={() => adjust(-1)}
-                        className="w-7 h-7 flex items-center justify-center border border-gray-200 rounded-l-lg bg-white hover:bg-gray-50 hover:border-violet-300 hover:text-indigo-600 text-gray-500 text-sm font-medium transition-all"
+                        className="w-10 h-10 sm:w-7 sm:h-7 flex items-center justify-center border border-gray-200 rounded-l-lg bg-white hover:bg-gray-50 hover:border-violet-300 hover:text-indigo-600 text-gray-500 text-sm font-medium transition-all"
                     >
                         −
                     </button>
                     <input
                         type="number"
+                        inputMode="numeric"
                         min={1}
                         max={999}
                         step={1}
@@ -465,7 +468,7 @@ function CatalogItemRow({
                             if ([".", "e", "E", "-", "+"].includes(e.key))
                                 e.preventDefault();
                         }}
-                        className={`w-10 h-7 border-y text-center text-xs font-semibold text-gray-900 outline-none transition-all ${
+                        className={`w-12 h-10 sm:w-10 sm:h-7 border-y text-center text-sm sm:text-xs font-semibold text-gray-900 outline-none transition-all ${
                             error
                                 ? "border-red-400 bg-red-50"
                                 : "border-gray-200 bg-white focus:border-indigo-400"
@@ -479,7 +482,7 @@ function CatalogItemRow({
                     />
                     <button
                         onClick={() => adjust(1)}
-                        className="w-7 h-7 flex items-center justify-center border border-gray-200 rounded-r-lg bg-white hover:bg-gray-50 hover:border-violet-300 hover:text-indigo-600 text-gray-500 text-sm font-medium transition-all"
+                        className="w-10 h-10 sm:w-7 sm:h-7 flex items-center justify-center border border-gray-200 rounded-r-lg bg-white hover:bg-gray-50 hover:border-violet-300 hover:text-indigo-600 text-gray-500 text-sm font-medium transition-all"
                     >
                         +
                     </button>
@@ -579,6 +582,8 @@ export default function NewOrderPage() {
     const [cart, setCart] = useState<Record<number, CartEntry>>({});
     const [notes, setNotes] = useState("");
     const [deliveryType, setDeliveryType] = useState<DeliveryType>("company");
+    // Mobile order-review sheet
+    const [reviewSheetOpen, setReviewSheetOpen] = useState(false);
 
     const orderableItems = useMemo(
         () =>
@@ -757,9 +762,9 @@ export default function NewOrderPage() {
 
             {/* ── Two-column layout ── */}
             <div className="flex flex-1 min-h-0">
-                {/* ── LEFT: Catalog ── */}
-                <div className="flex-1 flex flex-col border-r border-gray-100 overflow-hidden">
-                    <div className="flex items-center gap-2 px-5 py-3.5 border-b border-gray-100 flex-shrink-0">
+                {/* ── LEFT: Catalog (full-width on mobile, 1fr on desktop) ── */}
+                <div className="flex-1 flex flex-col md:border-r border-gray-100 overflow-hidden">
+                    <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 px-4 sm:px-5 py-3.5 border-b border-gray-100 flex-shrink-0">
                         <div className="relative flex-1">
                             <Search
                                 size={13}
@@ -769,7 +774,7 @@ export default function NewOrderPage() {
                                 value={search}
                                 onChange={(e) => setSearch(e.target.value)}
                                 placeholder="Search by name or SKU…"
-                                className="w-full border border-gray-200 rounded-xl pl-9 pr-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all"
+                                className="w-full border border-gray-200 rounded-xl pl-9 pr-3 py-2.5 sm:py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all"
                             />
                         </div>
                         <select
@@ -781,7 +786,7 @@ export default function NewOrderPage() {
                                         : "",
                                 )
                             }
-                            className="py-2 px-3 text-xs border border-gray-200 rounded-lg outline-none focus:border-indigo-400 bg-white text-gray-600 cursor-pointer transition-all"
+                            className="py-2.5 sm:py-2 px-3 text-xs border border-gray-200 rounded-lg outline-none focus:border-indigo-400 bg-white text-gray-600 cursor-pointer transition-all"
                         >
                             <option value="">All categories</option>
                             {(categories ?? []).map((c) => (
@@ -792,13 +797,14 @@ export default function NewOrderPage() {
                         </select>
                     </div>
 
-                    <div className="px-5 py-2 text-[11px] text-gray-300 flex-shrink-0">
+                    <div className="px-4 sm:px-5 py-2 text-[11px] text-gray-300 flex-shrink-0">
                         {filteredItems.length} item
                         {filteredItems.length !== 1 ? "s" : ""} available to
                         order
                     </div>
 
-                    <div className="flex-1 overflow-y-auto px-5 pb-5">
+                    {/* Extra bottom padding on mobile so last item clears the sticky bar */}
+                    <div className="flex-1 overflow-y-auto px-4 sm:px-5 pb-28 md:pb-5">
                         {catalogLoading ? (
                             <div className="flex items-center justify-center py-16 gap-2 text-gray-400">
                                 <Loader2 size={16} className="animate-spin" />
@@ -857,8 +863,8 @@ export default function NewOrderPage() {
                     </div>
                 </div>
 
-                {/* ── RIGHT: Order summary ── */}
-                <div className="w-72 flex flex-col flex-shrink-0 bg-gray-50/50">
+                {/* ── RIGHT: Order summary — hidden on mobile, visible md+ ── */}
+                <div className="hidden md:flex w-72 flex-col flex-shrink-0 bg-gray-50/50">
                     {/* Stats */}
                     <div className="px-4 pt-4 pb-3 border-b border-gray-100 bg-white flex-shrink-0">
                         <div className="flex items-center gap-2 mb-3">
@@ -1001,6 +1007,194 @@ export default function NewOrderPage() {
                     </div>
                 </div>
             </div>
+
+            {/* ── Mobile sticky cart bar (hidden on md+) ── */}
+            <div className="md:hidden flex-shrink-0 border-t border-gray-200 bg-white px-4 py-3 safe-area-bottom">
+                {hasItems ? (
+                    <div className="flex items-center gap-3">
+                        <div className="flex-1 min-w-0">
+                            <p className="text-sm font-bold text-gray-900 truncate">
+                                {totalItems} item{totalItems !== 1 ? "s" : ""} ·{" "}
+                                {totalBoxes} box{totalBoxes !== 1 ? "es" : ""}
+                            </p>
+                            <p className="text-[11px] text-gray-400">
+                                Tap to review before submitting
+                            </p>
+                        </div>
+                        <button
+                            onClick={() => setReviewSheetOpen(true)}
+                            className="flex items-center gap-2 px-5 py-3 rounded-xl bg-indigo-600 text-white text-sm font-semibold shadow-[0_2px_12px_rgba(99,102,241,.35)] active:scale-95 transition-transform"
+                        >
+                            <ShoppingCart size={15} />
+                            Review
+                            <ChevronUp size={14} className="opacity-70" />
+                        </button>
+                    </div>
+                ) : (
+                    <p className="text-xs text-gray-400 text-center py-1">
+                        Add items from the catalog to start your order
+                    </p>
+                )}
+            </div>
+
+            {/* ── Mobile order-review bottom sheet ── */}
+            <Sheet
+                isOpen={reviewSheetOpen}
+                onClose={() => setReviewSheetOpen(false)}
+                snapPoints={[0, 0.92, 1]}
+                initialSnap={1}
+                className="md:hidden"
+            >
+                <Sheet.Container>
+                    <Sheet.Header />
+                    <Sheet.Content>
+                        <div className="overflow-y-auto px-4 pb-10">
+                            {/* Header */}
+                            <div className="flex items-center gap-2 mb-4">
+                                <ShoppingCart
+                                    size={16}
+                                    className="text-indigo-500"
+                                />
+                                <span className="text-base font-bold text-gray-900">
+                                    Order Summary
+                                </span>
+                                <span className="ml-auto text-[10px] font-bold text-indigo-600 bg-indigo-100 px-2 py-0.5 rounded-full">
+                                    {totalItems} item{totalItems !== 1 ? "s" : ""}
+                                </span>
+                            </div>
+
+                            {/* Stats row */}
+                            <div className="grid grid-cols-2 gap-2 mb-4">
+                                {[
+                                    { val: totalItems, label: "Line items" },
+                                    { val: totalBoxes, label: "Total boxes" },
+                                ].map(({ val, label }) => (
+                                    <div
+                                        key={label}
+                                        className="bg-gray-100 rounded-xl px-4 py-3"
+                                    >
+                                        <div className="text-xl font-bold text-gray-900 tracking-tight">
+                                            {val}
+                                        </div>
+                                        <div className="text-[11px] text-gray-400 mt-0.5">
+                                            {label}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+
+                            {/* Cart items */}
+                            <div className="flex flex-col gap-1.5 mb-5">
+                                {cartEntries.map((entry) => (
+                                    <CartRow
+                                        key={entry.item.id}
+                                        entry={entry}
+                                        onRemove={() => {
+                                            handleRemove(entry.item.id);
+                                            if (
+                                                Object.keys(cart).length <= 1
+                                            ) {
+                                                setReviewSheetOpen(false);
+                                            }
+                                        }}
+                                    />
+                                ))}
+                            </div>
+
+                            {/* Divider */}
+                            <div className="border-t border-gray-100 mb-4" />
+
+                            {/* Delivery + Title + Notes */}
+                            <div className="flex flex-col gap-4 mb-5">
+                                <DeliveryTypeSelector
+                                    value={deliveryType}
+                                    onChange={setDeliveryType}
+                                />
+
+                                <div>
+                                    <label className="text-[11px] font-semibold text-gray-500 block mb-1.5">
+                                        Order Title{" "}
+                                        <span className="font-normal text-gray-300">
+                                            (optional)
+                                        </span>
+                                    </label>
+                                    <input
+                                        type="text"
+                                        value={title}
+                                        onChange={(e) =>
+                                            setTitle(e.target.value)
+                                        }
+                                        placeholder="e.g. Nutella for Bay Ridge…"
+                                        className="w-full border border-gray-200 rounded-xl px-3 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all"
+                                    />
+                                </div>
+
+                                <div>
+                                    <label className="text-[11px] font-semibold text-gray-500 block mb-1.5">
+                                        Notes{" "}
+                                        <span className="font-normal text-gray-300">
+                                            (optional)
+                                        </span>
+                                    </label>
+                                    <textarea
+                                        value={notes}
+                                        onChange={(e) =>
+                                            setNotes(e.target.value)
+                                        }
+                                        rows={2}
+                                        placeholder="e.g. Please prioritize Nutella…"
+                                        className="w-full border border-gray-200 rounded-xl px-3 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all resize-none"
+                                    />
+                                </div>
+                            </div>
+
+                            {/* Action buttons */}
+                            <div className="flex flex-col gap-2">
+                                <button
+                                    onClick={() => {
+                                        setReviewSheetOpen(false);
+                                        handleSubmit();
+                                    }}
+                                    disabled={
+                                        !hasItems ||
+                                        isSubmitting ||
+                                        missingContext
+                                    }
+                                    className="w-full py-3.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-semibold transition-all flex items-center justify-center gap-2 shadow-[0_2px_12px_rgba(99,102,241,.3)]"
+                                >
+                                    {isSubmitting && (
+                                        <Loader2
+                                            size={14}
+                                            className="animate-spin"
+                                        />
+                                    )}
+                                    Submit Order
+                                </button>
+                                <button
+                                    onClick={() => {
+                                        setReviewSheetOpen(false);
+                                        handleDraft();
+                                    }}
+                                    disabled={
+                                        !hasItems ||
+                                        isSubmitting ||
+                                        missingContext
+                                    }
+                                    className="w-full py-3.5 rounded-xl border border-gray-200 bg-white hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed text-gray-700 text-sm font-semibold transition-all"
+                                >
+                                    Save as Draft
+                                </button>
+                            </div>
+
+                            <p className="text-[10px] text-gray-300 text-center mt-3 leading-relaxed">
+                                Submitting sends this order to the warehouse for
+                                fulfillment.
+                            </p>
+                        </div>
+                    </Sheet.Content>
+                </Sheet.Container>
+                <Sheet.Backdrop onTap={() => setReviewSheetOpen(false)} />
+            </Sheet>
         </div>
     );
 }

--- a/components/orders/ConfirmOrderSheet.tsx
+++ b/components/orders/ConfirmOrderSheet.tsx
@@ -7,6 +7,10 @@
  * Each item is pre-filled with the expected box count from the warehouse.
  * Employee changes the value if what physically arrived differs.
  *
+ * On mobile, tapping an item's quantity cell opens the NumericKeypad
+ * for large-thumb-friendly entry. On desktop, a standard number input
+ * is shown inline instead.
+ *
  * Discrepant rows are highlighted in amber live as the employee types.
  * On submit, actual quantities go to the store inventory (not expected),
  * and the discrepancy is logged for super admin review.
@@ -42,6 +46,7 @@ import { Label }  from "@/components/ui/label";
 import { Badge }  from "@/components/ui/badge";
 import { useConfirmTicket } from "@/lib/hooks/queries/useOrderTickets";
 import type { ReceivedItem } from "@/lib/supabase/queries/orderTickets";
+import NumericKeypad from "@/components/employee/inventory/NumericKeypad";
 
 interface LineItem {
 	itemId:         number;
@@ -70,6 +75,9 @@ export function ConfirmOrderSheet({
 	const [counts, setCounts] = useState<Record<number, string>>(() =>
 		Object.fromEntries(lineItems.map((li) => [li.itemId, String(li.fulfilledBoxes)])),
 	);
+
+	// Track which item's NumericKeypad is open (mobile)
+	const [keypadItemId, setKeypadItemId] = useState<number | null>(null);
 
 	const { mutate: confirm, isPending } = useConfirmTicket();
 
@@ -159,11 +167,12 @@ export function ConfirmOrderSheet({
 						const actual       = parseInt(counts[li.itemId] ?? "", 10);
 						const isDiscrepant = !isNaN(actual) && actual !== li.fulfilledBoxes;
 						const diff         = isNaN(actual) ? 0 : actual - li.fulfilledBoxes;
+						const isKeypadOpen = keypadItemId === li.itemId;
 
 						return (
 							<div
 								key={li.itemId}
-								className={`rounded-lg border p-3 transition-colors ${
+								className={`rounded-xl border p-3 transition-colors ${
 									isDiscrepant
 										? "border-amber-300 bg-amber-50"
 										: "border-border bg-background"
@@ -191,6 +200,26 @@ export function ConfirmOrderSheet({
 									</div>
 								</div>
 
+								{/* Mobile: tappable cell that opens NumericKeypad */}
+								<button
+									type="button"
+									onClick={() => setKeypadItemId(li.itemId)}
+									className={`sm:hidden w-full h-14 flex items-center justify-center rounded-xl border-2 transition-colors ${
+										isKeypadOpen
+											? "border-indigo-500 bg-indigo-50"
+											: isDiscrepant
+											  ? "border-amber-400 bg-amber-100"
+											  : "border-gray-200 bg-gray-50 active:bg-gray-100"
+									}`}
+								>
+									<span className={`text-2xl font-bold ${
+										isDiscrepant ? "text-amber-700" : "text-gray-900"
+									}`}>
+										{counts[li.itemId] !== "" ? counts[li.itemId] : "—"}
+									</span>
+								</button>
+
+								{/* Desktop: standard number input */}
 								<Input
 									id={`item-${li.itemId}`}
 									type="number"
@@ -198,7 +227,7 @@ export function ConfirmOrderSheet({
 									min={0}
 									value={counts[li.itemId]}
 									onChange={(e) => handleChange(li.itemId, e.target.value)}
-									className={`h-11 text-center text-lg font-semibold ${
+									className={`hidden sm:flex h-11 text-center text-lg font-semibold ${
 										isDiscrepant
 											? "border-amber-400 focus-visible:ring-amber-400"
 											: ""
@@ -209,6 +238,34 @@ export function ConfirmOrderSheet({
 						);
 					})}
 				</div>
+
+				{/* NumericKeypad for mobile quantity entry */}
+				{keypadItemId !== null && (
+					<NumericKeypad
+						isOpen={true}
+						value={counts[keypadItemId] ?? ""}
+						onClose={() => setKeypadItemId(null)}
+						onInput={(char) => {
+							// Box counts are integers only — ignore decimal
+							if (char === ".") return;
+							const current = counts[keypadItemId] ?? "";
+							// Replace leading zero when typing a new digit
+							const newVal = current === "0" ? char : current + char;
+							if (/^\d+$/.test(newVal)) {
+								setCounts((prev) => ({ ...prev, [keypadItemId]: newVal }));
+							}
+						}}
+						onBackspace={() => {
+							const current = counts[keypadItemId] ?? "";
+							const newVal = current.slice(0, -1);
+							setCounts((prev) => ({
+								...prev,
+								[keypadItemId]: newVal,
+							}));
+						}}
+						onEnter={() => setKeypadItemId(null)}
+					/>
+				)}
 
 				<SheetFooter className="gap-2 pt-4">
 					<Button

--- a/email/DailyLocationSummary.tsx
+++ b/email/DailyLocationSummary.tsx
@@ -181,6 +181,111 @@ export default function DailyLocationSummary({ summaryData }: DailyLocationSumma
                             </Section>
                         )}
 
+                        {/* ── Warehouse Section (super admin only) ── */}
+                        {summaryData.warehouseSummary && (
+                            <Section style={warehouseSection}>
+                                {/* Section header */}
+                                <Section style={warehouseHeader}>
+                                    <Heading style={warehouseTitle}>
+                                        🏭 Warehouse Summary
+                                    </Heading>
+                                    <Text style={warehouseSubtitle}>
+                                        Central warehouse activity for{' '}
+                                        {new Date(summaryData.date).toLocaleDateString('en-US', {
+                                            weekday: 'long',
+                                            month: 'long',
+                                            day: 'numeric',
+                                        })}
+                                    </Text>
+                                </Section>
+
+                                {/* Key metrics row */}
+                                <Row style={{ marginBottom: '20px' }}>
+                                    <Column style={warehouseMetricColumn}>
+                                        <Text style={warehouseMetricValue}>
+                                            {summaryData.warehouseSummary.ticketsFulfilledToday}
+                                        </Text>
+                                        <Text style={warehouseMetricLabel}>
+                                            Orders Fulfilled
+                                        </Text>
+                                    </Column>
+                                    <Column style={warehouseMetricColumn}>
+                                        <Text style={warehouseMetricValue}>
+                                            {summaryData.warehouseSummary.itemsDispatchedToday.length}
+                                        </Text>
+                                        <Text style={warehouseMetricLabel}>
+                                            Item Types Dispatched
+                                        </Text>
+                                    </Column>
+                                    <Column style={warehouseMetricColumn}>
+                                        <Text style={warehouseMetricValue}>
+                                            {summaryData.warehouseSummary.itemsDispatchedToday.reduce(
+                                                (sum, i) => sum + i.totalBoxes, 0,
+                                            )}
+                                        </Text>
+                                        <Text style={warehouseMetricLabel}>
+                                            Total Boxes Sent
+                                        </Text>
+                                    </Column>
+                                </Row>
+
+                                {/* Stock health bar */}
+                                <Section style={stockHealthBox}>
+                                    <Text style={stockHealthTitle}>📦 Warehouse Stock Health</Text>
+                                    <Row>
+                                        <Column style={{ width: '60%' }}>
+                                            <Text style={stockHealthPercent}>
+                                                {summaryData.warehouseSummary.stockHealth.healthPercent}%
+                                            </Text>
+                                            <Text style={stockHealthLabel}>items at healthy levels</Text>
+                                        </Column>
+                                        <Column style={{ width: '40%', textAlign: 'right' as const }}>
+                                            {summaryData.warehouseSummary.stockHealth.lowStockCount > 0 && (
+                                                <Text style={stockHealthWarning}>
+                                                    ⚠️ {summaryData.warehouseSummary.stockHealth.lowStockCount} low stock
+                                                </Text>
+                                            )}
+                                            {summaryData.warehouseSummary.stockHealth.criticalCount > 0 && (
+                                                <Text style={stockHealthCritical}>
+                                                    🔴 {summaryData.warehouseSummary.stockHealth.criticalCount} critical
+                                                </Text>
+                                            )}
+                                            {summaryData.warehouseSummary.stockHealth.lowStockCount === 0 &&
+                                             summaryData.warehouseSummary.stockHealth.criticalCount === 0 && (
+                                                <Text style={stockHealthGood}>✅ All good</Text>
+                                            )}
+                                        </Column>
+                                    </Row>
+                                </Section>
+
+                                {/* Items dispatched today */}
+                                {summaryData.warehouseSummary.itemsDispatchedToday.length > 0 && (
+                                    <Section style={{ marginTop: '16px' }}>
+                                        <Text style={dispatchedTitle}>📤 Items Dispatched Today</Text>
+                                        {summaryData.warehouseSummary.itemsDispatchedToday.slice(0, 8).map((item, index) => (
+                                            <Section key={index} style={dispatchedRow}>
+                                                <Row>
+                                                    <Column style={{ width: '65%' }}>
+                                                        <Text style={dispatchedItemName}>{item.itemName}</Text>
+                                                    </Column>
+                                                    <Column style={{ width: '35%', textAlign: 'right' as const }}>
+                                                        <Text style={dispatchedItemQty}>
+                                                            {item.totalBoxes} box{item.totalBoxes !== 1 ? 'es' : ''}
+                                                        </Text>
+                                                    </Column>
+                                                </Row>
+                                            </Section>
+                                        ))}
+                                        {summaryData.warehouseSummary.itemsDispatchedToday.length > 8 && (
+                                            <Text style={moreItemsText}>
+                                                ...and {summaryData.warehouseSummary.itemsDispatchedToday.length - 8} more items dispatched
+                                            </Text>
+                                        )}
+                                    </Section>
+                                )}
+                            </Section>
+                        )}
+
                         {/* Action Button */}
                         <Section style={actionSection}>
                             <Button
@@ -417,5 +522,133 @@ const footerSignature = {
     fontSize: '12px',
     color: '#9ca3af',
     margin: '0',
+};
+
+// ── Warehouse section styles ──────────────────────────────────────────────────
+
+const warehouseSection = {
+    marginBottom: '30px',
+    border: '1px solid #d1fae5',
+    borderRadius: '8px',
+    overflow: 'hidden' as const,
+};
+
+const warehouseHeader = {
+    backgroundColor: '#065f46',
+    padding: '18px 20px 14px',
+};
+
+const warehouseTitle = {
+    fontSize: '18px',
+    fontWeight: 'bold' as const,
+    color: '#ffffff',
+    margin: '0 0 6px',
+};
+
+const warehouseSubtitle = {
+    fontSize: '13px',
+    color: '#a7f3d0',
+    margin: '0',
+};
+
+const warehouseMetricColumn = {
+    textAlign: 'center' as const,
+    padding: '14px 8px',
+    backgroundColor: '#ecfdf5',
+};
+
+const warehouseMetricValue = {
+    fontSize: '26px',
+    fontWeight: 'bold' as const,
+    color: '#065f46',
+    margin: '0 0 4px',
+};
+
+const warehouseMetricLabel = {
+    fontSize: '11px',
+    color: '#6b7280',
+    margin: '0',
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.4px',
+};
+
+const stockHealthBox = {
+    backgroundColor: '#f9fafb',
+    border: '1px solid #e5e7eb',
+    borderRadius: '6px',
+    padding: '14px 16px',
+    margin: '0 16px 4px',
+};
+
+const stockHealthTitle = {
+    fontSize: '13px',
+    fontWeight: 'bold' as const,
+    color: '#374151',
+    margin: '0 0 8px',
+};
+
+const stockHealthPercent = {
+    fontSize: '28px',
+    fontWeight: 'bold' as const,
+    color: '#059669',
+    margin: '0 0 2px',
+};
+
+const stockHealthLabel = {
+    fontSize: '12px',
+    color: '#6b7280',
+    margin: '0',
+};
+
+const stockHealthWarning = {
+    fontSize: '12px',
+    fontWeight: '600' as const,
+    color: '#d97706',
+    margin: '0 0 4px',
+    textAlign: 'right' as const,
+};
+
+const stockHealthCritical = {
+    fontSize: '12px',
+    fontWeight: '600' as const,
+    color: '#dc2626',
+    margin: '0',
+    textAlign: 'right' as const,
+};
+
+const stockHealthGood = {
+    fontSize: '12px',
+    fontWeight: '600' as const,
+    color: '#059669',
+    margin: '0',
+    textAlign: 'right' as const,
+};
+
+const dispatchedTitle = {
+    fontSize: '13px',
+    fontWeight: 'bold' as const,
+    color: '#374151',
+    margin: '0 0 8px',
+    padding: '0 16px',
+};
+
+const dispatchedRow = {
+    padding: '8px 16px',
+    borderBottom: '1px solid #f3f4f6',
+};
+
+const dispatchedItemName = {
+    fontSize: '13px',
+    fontWeight: '500' as const,
+    color: '#111827',
+    margin: '0',
+};
+
+const dispatchedItemQty = {
+    fontSize: '13px',
+    fontWeight: '600' as const,
+    color: '#065f46',
+    margin: '0',
+    textAlign: 'right' as const,
 };
 

--- a/lib/utils/emailDataBuilders.ts
+++ b/lib/utils/emailDataBuilders.ts
@@ -92,6 +92,29 @@ export interface DailySummaryData {
             direction: 'up' | 'down';
         }>;
     };
+    /**
+     * Present only for super admin recipients — summarises warehouse
+     * activity for the day (tickets fulfilled, items dispatched, stock health).
+     */
+    warehouseSummary?: {
+        /** Total order tickets fulfilled today across all stores. */
+        ticketsFulfilledToday: number;
+        /** Per-item dispatch totals sent out to stores today. */
+        itemsDispatchedToday: Array<{
+            itemId: string;
+            itemName: string;
+            totalBoxes: number;
+            totalUnits: number;
+        }>;
+        /** High-level warehouse stock health snapshot. */
+        stockHealth: {
+            totalItems: number;
+            lowStockCount: number;
+            criticalCount: number;
+            /** Percentage of items that are at healthy stock levels (0–100). */
+            healthPercent: number;
+        };
+    };
 }
 
 /**


### PR DESCRIPTION
5.4 — Mobile optimization for ticket flows:
- Ticket detail ([id]/page): responsive top bar (flex-col → sm:flex-row), responsive body grid (grid-cols-1 → md:grid-cols-[1fr_272px]), and a dual-layout StatusTimeline (vertical on mobile, horizontal on sm+)
- New order creation (new/page): catalog goes full-width on mobile, desktop sidebar hidden with md:flex; sticky bottom cart bar shows item/box count
  + "Review" button that opens a react-modal-sheet with cart, delivery selector, title, notes, and submit/draft actions; quantity ±buttons enlarged to 40px touch targets on mobile (sm: stays 28px)
- ConfirmOrderSheet: on mobile, each item row shows a large tappable cell (h-14, text-2xl) that opens the existing NumericKeypad portal for thumb-friendly box-count entry; standard Input retained on desktop

5.3 — Extend daily summary for warehouse:
- DailySummaryData interface gains optional warehouseSummary field: ticketsFulfilledToday, itemsDispatchedToday[], and stockHealth snapshot
- DailyLocationSummary email template renders a 🏭 Warehouse Summary section (gated on warehouseSummary presence) with fulfilled-order metrics, per-item dispatch table, and a stock-health bar